### PR TITLE
Remove OH websocket error message

### DIFF
--- a/frontend/src/context/ws-client-provider-openhands.tsx
+++ b/frontend/src/context/ws-client-provider-openhands.tsx
@@ -238,11 +238,11 @@ export function WsClientProvider({
     sio.io.opts.query.latest_event_id = lastEventRef.current?.id;
     updateStatusWhenErrorMessagePresent(data);
 
-    // setErrorMessage(
-    //   hasValidMessageProperty(data)
-    //     ? data.message
-    //     : "The WebSocket connection was closed.",
-    // );
+    setErrorMessage(
+      hasValidMessageProperty(data)
+        ? data.message
+        : "The WebSocket connection was closed.",
+    );
   }
 
   function handleError(data: unknown) {


### PR DESCRIPTION
As reported on the offsite, this message appears too much on the OH side and since we are handling connection to the websocket ourselves, we can remove it.